### PR TITLE
Katex

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -12,11 +12,20 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
       - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
 
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:
-          mdbook-version: '0.4.18'
+          mdbook-version: "0.4.21"
+
+      - name: Install mdbook-katex
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --git "https://github.com/sinui0/mdbook-katex"
 
       - run: mdbook build
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# TLSNotary mdBook Documentation
+
+## Build
+
+Install mdbook and mdbook-katex
+
+```bash
+cargo install mdbook --version 0.4.21
+cargo install --git "https://github.com/sinui0/mdbook-katex"
+```
+
+Then build and serve
+
+```bash
+mdbook serve
+```

--- a/book.toml
+++ b/book.toml
@@ -6,5 +6,8 @@ src = "src"
 title = "tlsn-docs"
 
 [output.html]
-mathjax-support = true
 default-theme = "ayu"
+
+[output.katex]
+
+[preprocessor.katex]

--- a/book.toml
+++ b/book.toml
@@ -7,6 +7,7 @@ title = "tlsn-docs"
 
 [output.html]
 default-theme = "ayu"
+additional-css = ["src/css/katex.css"]
 
 [output.katex]
 

--- a/src/css/katex.css
+++ b/src/css/katex.css
@@ -1,0 +1,3 @@
+.katex {
+  font-size: 1em !important;
+}

--- a/src/protocol/2pc/dual_execution_with_privacy_only_for_the_user.md
+++ b/src/protocol/2pc/dual_execution_with_privacy_only_for_the_user.md
@@ -19,7 +19,7 @@ Secondly, we observe that the Notary's keyshare is an _ephemeral secret_: it is 
 
 * $p$ is the User's plaintext request
 * $k$ is the AES key
-* $[k]\_1$ and $[k]\_2$ are the User's and Notary's AES keyshares, respectively. That is, $k = [k]\_1 \oplus [k]\_2$.
+* $k_u$ and $k_n$ are the User's and Notary's AES keyshares, respectively. That is, $k = k_u \oplus k_n$.
 * $\mathsf{Enc}$ denotes the encryption algorithm used by the TLS session
 * $\mathsf{PRG}$ denotes a pseudorandom generator
 * $\mathsf{com}_x$ denotes a binding commitment to the value $x$
@@ -30,13 +30,13 @@ We define the ideal functionality we wish to instantiate. In words, the function
 
 Ideal functionality for ONESHOTENC:
 
-1. User → ℱ: $p, [k]\_1$
-2. Notary → ℱ: $[k]\_2$
-3. ℱ → User: $\mathsf{Enc}\_k(p)$
-4. ℱ → Notary: $\mathsf{Enc}\_k(p)$
-5. User → ℱ: $\mathsf{com}\_\mathsf{resp}$
+1. User → ℱ: $p, k_u$
+2. Notary → ℱ: $k_n$
+3. ℱ → User: $\mathsf{Enc}_k(p)$
+4. ℱ → Notary: $\mathsf{Enc}_k(p)$
+5. User → ℱ: $\mathsf{com}_\mathsf{resp}$
 6. ℱ → User: $k$
-7. ℱ → Notary: $\mathsf{com}\_\mathsf{resp}$
+7. ℱ → Notary: $\mathsf{com}_\mathsf{resp}$
 
 ## Protocol
 
@@ -48,8 +48,8 @@ To set up for dual-execution, the parties set up the OTs. Because we have a priv
 In the first step of the protocol, the User has to get her AES ciphertext from the Notary. The User does not trust the Notary (for privacy or integrity), and the User's data is far more sensitive to leakage than the Notary's. So the parties do an ordinary DualEx:
 
 0. The User and Notary both garble a copy of the encryption circuit, and do OTs for each other. For committed OT the Notary constructs the input wire labels and OT encryption keys as $\mathsf{PRG}(\rho)$ where $\rho$ is a randomly sampled PRG seed, and sends $\mathsf{com}_\rho$ to the User after the OT is done.
-1. The User sends her garbled encryption circuit and garbled wires for $[k]\_1$ and $p$. She also sends the output decoding information.
-2. The Notary uses his OT values to evaluate the circuit on $[k]\_2$. He derives the encoded ciphertext $C$ and decodes it into ciphertext $c$ using output decoding information.[^1]
+1. The User sends her garbled encryption circuit and garbled wires for $k_u$ and $p$. She also sends the output decoding information.
+2. The Notary uses his OT values to evaluate the circuit on $k_n$. He derives the encoded ciphertext $C$ and decodes it into ciphertext $c$ using output decoding information.[^1]
 3. The Notary sends $C$ to the User.[^2]
 
     Step 3 is a relaxation of DualEx. In DualEx, the User would not learn the Notary's evaluation output at this point. As mentioned earlier, in TLSNotary protocol's setting, we are not worried that $C$ may leak the Notary's input, as long as this behaviour will be detected later. Also we are not worried about DualEx's inherent 1-bit leakage since it gives no meaningful advantage to the User as explained earlier. 
@@ -75,10 +75,10 @@ Also at this point, the User has learned the ciphertext, and, if malicious, has 
 
 ### Part 3
 
-Now that the session is over and $[k]\_2$ is no longer secret, the Notary can switch to privacy-free garbling for the second part of DualEx.
+Now that the session is over and $k_n$ is no longer secret, the Notary can switch to privacy-free garbling for the second part of DualEx.
 
-7. The Notary sends his garbled encryption circuit to the User, as well as the garbled wires for $[k]\_2$. He also sends the output decoding information.
-8. The User evaluates the circuit on $[k]\_1$ and $p$, using the OT values from step 0, derives the encoded ciphertext $C'$ and decodes it into ciphertext $c$ using output decoding information.
+7. The Notary sends his garbled encryption circuit to the User, as well as the garbled wires for $k_n$. He also sends the output decoding information.
+8. The User evaluates the circuit on $k_u$ and $p$, using the OT values from step 0, derives the encoded ciphertext $C'$ and decodes it into ciphertext $c$ using output decoding information.
 9. As per DualEx, she computes $Check_u = H(w_A || W_A^{v_A})$ and sends a commitment $\mathsf{com}\_{Check_u}$ to the Notary.
 
     Note that at this stage the Notary could reveal $Check_n$ and the User would make sure that $Check_n == Check_u$. Then likewise the User would reveal $Check_u$ and the Notary would make sure that $Check_n == Check_u$.

--- a/src/protocol/2pc/mac.md
+++ b/src/protocol/2pc/mac.md
@@ -39,24 +39,24 @@ the TLS record).
 
 The `GHASH output` is the output of the GHASH function described in the
 [NIST publication](https://nvlpubs.nist.gov/nistpubs/legacy/sp/nistspecialpublication800-38d.pdf)
-in section 6.4 in this way: "In effect, the GHASH function calculates \\(
-\small{ X_1•H^{m} ⊕ X_2•H^{m−1} ⊕ ... ⊕ X_{m−1}•H^{2} ⊕ X_m•H } \\)". \\(H\\)
-and \\(X\\) are elements of the extension field \\(\mathrm{GF}(2^{128})\\).
+in section 6.4 in this way: "In effect, the GHASH function calculates $
+X_1•H^{m} ⊕ X_2•H^{m−1} ⊕ ... ⊕ X_{m−1}•H^{2} ⊕ X_m•H$". $H$
+and $X$ are elements of the extension field $\mathrm{GF}(2^{128})$.
 
 * "•" is a special type of multiplication called `multiplication in a finite
 field` described in section 6.3 of the NIST publication.
 * ⊕ is `addition in a finite field` and it is defined as XOR.
 
 In other words, GHASH splits up the ciphertext into 16-byte blocks, each block
-is numbered \\( \small{ X_1, X_2, ... }\\) etc. There's also \\( \small{H} \\)
+is numbered $X_1, X_2, ...$ etc. There's also $ H $
 which is called the `GHASH key`, which just is the AES-encrypted zero-block. We
-need to raise \\( \small{H} \\) to as many powers as there are blocks, i.e. if
-we have 5 blocks then we need 5 powers: \\( \small{ H, H^2, H^3, H^4, H^5 } \\).
+need to raise $ H $ to as many powers as there are blocks, i.e. if
+we have 5 blocks then we need 5 powers: $H, H^2, H^3, H^4, H^5$.
 Each block is multiplied by the corresponding power and all products are summed
 together.
 
 Below is the pseudocode for multiplying two 128-bit field elements `x` and `y`
-in \\(\mathrm{GF}(2^{128})\\):
+in $\mathrm{GF}(2^{128})$:
 
 ```
 1. result = 0
@@ -69,45 +69,45 @@ in \\(\mathrm{GF}(2^{128})\\):
 8. return result
 ```
 
-Standard math properties hold in finite field math, viz. commutative: \\(
-\small{ a+b=b+a } \\) and distributive: \\( \small{ a(b+c)=ab+ac } \\).
+Standard math properties hold in finite field math, viz. commutative: $a+b=b+a$
+and distributive: $a(b+c)=ab+ac$.
 
 
 ## 3. Computing MAC using secure two-party computation (2PC) <a name="section3"></a>
 
 The goal of the protocol is to compute the MAC in such a way that neither party
-would learn the other party's share of \\( \small{ H } \\) i.e. the `GHASH key`
+would learn the other party's share of $ H $ i.e. the `GHASH key`
 share. At the start of the protocol each party has:
-1. ciphertext blocks \\( \small{ X_1, X_2, ..., X_m } \\).
-2. his XOR share of \\( \small{ H } \\): the `User` has \\( \small{ H_u } \\)
-   and the `Notary` has \\( \small{ H_n } \\).
-3. his XOR share of the `GCTR output`: the `User` has \\( \small{ GCTR_u } \\)
-   and the `Notary` has \\( \small{ GCTR_n } \\).
+1. ciphertext blocks $X_1, X_2, ..., X_m$.
+2. his XOR share of $ H $: the `User` has $ H_u $
+   and the `Notary` has $ H_n $.
+3. his XOR share of the `GCTR output`: the `User` has $ GCTR_u $
+   and the `Notary` has $ GCTR_n $.
 
 Note that **2.** and **3.** were obtained at an earlier stage of the TLSNotary protocol.
 
 ### 3.1 Example with a single ciphertext block
 
 To illustrate what we want to achieve, we consider the case of just having
-a single ciphertext block \\( \small{ X_1 } \\). The `GHASH_output` will be:
+a single ciphertext block $ X_1 $. The `GHASH_output` will be:
 
-\\( \small{ X_1•H = X_1•(H_u ⊕ H_n) = X_1•H_u ⊕ X_1•H_n } \\)
+$X_1•H = X_1•(H_u ⊕ H_n) = X_1•H_u ⊕ X_1•H_n$
 
 The `User` and the `Notary` will compute locally the left and the right terms
 respectively. Then each party will XOR their result to the `GCTR output` share
 and will get their XOR share of the MAC:
 
-`User`  : \\( \small{X_1 • H_u \\quad ⊕ \\quad GCTR_u = MAC_u} \\)
+`User`  : $X_1 • H_u \quad ⊕ \quad GCTR_u = MAC_u$
 
-`Notary`: \\( \small{X_1 • H_n \\quad ⊕ \\quad GCTR_n = MAC_n} \\)
+`Notary`: $X_1 • H_n \quad ⊕ \quad GCTR_n = MAC_n$
 
-Finally, the `Notary` sends \\( \small{MAC_n}\\) to the `User` who obtains: 
+Finally, the `Notary` sends $ MAC_n$ to the `User` who obtains: 
 
-\\( \small{ MAC = MAC_n \\quad ⊕ \\quad MAC_u} \\)
+$MAC = MAC_n \quad ⊕ \quad MAC_u$
 
 **For longer ciphertexts, the problem is that higher powers of the hashkey
-\\(H^k\\) cannot be computed locally, because we deal with additive sharings,
-i.e.\\( (H_u)^k ⊕ (H_n)^k \neq H^k\\).** 
+$H^k$ cannot be computed locally, because we deal with additive sharings,
+i.e.$ (H_u)^k ⊕ (H_n)^k \neq H^k$.** 
 
 ### 3.2 Computing ciphertexts with an arbitrary number of blocks
 We now introduce our 2PC MAC protocol for computing ciphertexts with an
@@ -116,16 +116,16 @@ steps.
 
 ##### Steps
 
-1. First, both parties convert their **additive** shares \\(H_u\\) and \\(H_n\\) into
-   **multiplicative** shares \\(\overline{H}_u\\) and \\(\overline{H}_n\\).
+1. First, both parties convert their **additive** shares $H_u$ and $H_n$ into
+   **multiplicative** shares $\overline{H}_u$ and $\overline{H}_n$.
 2. This allows each party to **locally** compute the needed higher powers of these multiplicative
-   shares, i.e for \\(m\\) blocks of ciphertext:
-   - the user computes \\(\overline{H_u}^2, \overline{H_u}^3, ... \overline{H_u}^m\\) 
-   - the notary computes \\(\overline{H_n}^2, \overline{H_n}^3, ... \overline{H_n}^m\\) 
+   shares, i.e for $m$ blocks of ciphertext:
+   - the user computes $\overline{H_u}^2, \overline{H_u}^3, ... \overline{H_u}^m$ 
+   - the notary computes $\overline{H_n}^2, \overline{H_n}^3, ... \overline{H_n}^m$ 
 3. Then both parties convert each of these multiplicative shares back to additive shares
-   - the user ends up with \\(H_u, H_u^2, ... H_u^m\\) 
-   - the notary ends up with \\(H_n, H_n^2, ... H_n^m\\) 
-4. Each party can now **locally** compute their additive MAC share \\(MAC_{n/u}\\).
+   - the user ends up with $H_u, H_u^2, ... H_u^m$ 
+   - the notary ends up with $H_n, H_n^2, ... H_n^m$ 
+4. Each party can now **locally** compute their additive MAC share $MAC_{n/u}$.
 
 The conversion steps (**1** and **3**) require communication between the user
 and the notary. They will use **A2M** (Addition-to-Multiplication) and **M2A**
@@ -137,54 +137,56 @@ the receiver.**
 
 #### 3.2.1 (A2M) Convert additive shares of H into multiplicative share
 
-At first (step **1**) we have to get a multiplicative share of \\(H_{n/u}\\),
+At first (step **1**) we have to get a multiplicative share of $H_{n/u}$,
 so that notary and user can locally compute the needed higher powers. For this
 we use an adapted version of the A2M protocol in chapter 4 of [Efficient Secure
 Two-Party Exponentiation](https://www.cs.umd.edu/~fenghao/paper/modexp.pdf).
 
-The user will decompose his share into \\(i\\) individual oblivious transfers
-\\(t_{u, i}^k = R \cdot (k \cdot 2^i + H_{u, i} \cdot 2^i ⊕ s_i)\\), where
-- \\(R\\) is some random value used for all oblivious transfers
-- \\(s_i\\) is a random mask used per oblivious transfer, with \\(\sum_i s_i = 0\\)
-- \\(k \in \\{0, 1\\}\\) depending on the receiver's choice.
+The user will decompose his share into $i$ individual oblivious transfers
+$t_{u, i}^k = R \cdot (k \cdot 2^i + H_{u, i} \cdot 2^i ⊕ s_i)$, where
+- $R$ is some random value used for all oblivious transfers
+- $s_i$ is a random mask used per oblivious transfer, with $\sum_i s_i = 0$
+- $k \in \\{0, 1\\}$ depending on the receiver's choice.
 
 The notary's choice in the i-th OT will depend on the bit value in the i-th
-position of his additive share \\(H_n\\). In the end the multiplicative share of
-the user \\(\overline{H_u}\\) will simply be the inverse \\(R^{-1}\\) of the
+position of his additive share $H_n$. In the end the multiplicative share of
+the user $\overline{H_u}$ will simply be the inverse $R^{-1}$ of the
 random value, and the notary will sum all his OT outputs, so that all the
-\\(s_i\\) will vanish and hence he gets his multiplicative share
-\\(\overline{H_n}\\).
+$s_i$ will vanish and hence he gets his multiplicative share
+$\overline{H_n}$.
 
+$$
 \begin{align}
 H &= H_u ⊕ H_n \\\\
 &= R^{-1} \cdot R \cdot \sum_i (H_{u,i} ⊕ H_{n, i}) \cdot 2^i ⊕ s_i \\\\
 &= R^{-1} \cdot \sum_i t_{u, i}^{H_{n, i}} ⊕ R \cdot \sum_i s_i \\\\
 &= \overline{H_u} \cdot \overline{H_n}
 \end{align}
+$$
 
 
-
-#### 3.2.2 (M2A) Convert multiplicative shares \\(\overline{H^k}\\) into additive shares
+#### 3.2.2 (M2A) Convert multiplicative shares $\overline{H^k}$ into additive shares
 
 In step **3** of our protocol, we use the oblivious transfer method described
 in chapter 4.1 of [Two Party RSA Key
 Generation](https://link.springer.com/content/pdf/10.1007/3-540-48405-1_8.pdf)
-to convert all the multiplicative shares \\(\overline{H_{n/u}^k}\\) back into
-additive shares \\(H_{n/u}^k\\). We only show how the method works for the share
-\\(\overline{H_{n/u}^1}\\), because it is the same for higher powers.
+to convert all the multiplicative shares $\overline{H_{n/u}^k}$ back into
+additive shares $H_{n/u}^k$. We only show how the method works for the share
+$\overline{H_{n/u}^1}$, because it is the same for higher powers.
 
-The user will be the OT sender and decompose his shares into \\(i\\) individual
-oblivious transfers \\(t_{u,i}^k = k \cdot \overline{H_u} \cdot 2^i + s_i\\),
-where \\(k \in \\{0, 1\\}\\), depending on the receiver's choices. Each of these
-OTs is masked with a random value \\(s_i\\). He will then obliviously send these
+The user will be the OT sender and decompose his shares into $i$ individual
+oblivious transfers $t_{u,i}^k = k \cdot \overline{H_u} \cdot 2^i + s_i$,
+where $k \in \\{0, 1\\}$, depending on the receiver's choices. Each of these
+OTs is masked with a random value $s_i$. He will then obliviously send these
 packages to the notary. Depending on the binary representation of his
 multiplicative share, the notary will choose one of the choices and do this for
 all 128 oblivious transfers.
 
-After that the user will locally XOR all his \\(s_i\\) and end up with his additive
-share \\(H_u\\), and the notary will do the same for all the results of the
-oblivious transfers and get \\(H_n\\).
+After that the user will locally XOR all his $s_i$ and end up with his additive
+share $H_u$, and the notary will do the same for all the results of the
+oblivious transfers and get $H_n$.
 
+$$
 \begin{aligned}
 \overline{H} &= \overline{H_u} \cdot \overline{H_n} \\\\
 &= \overline{H_u} \cdot \sum_i \overline{H_{n, i}} \cdot 2^i \\\\
@@ -192,21 +194,24 @@ oblivious transfers and get \\(H_n\\).
 &= \sum_i t_{u, i}^{\overline{H_{n, i}}} ⊕ \sum_i s_i \\\\
 &\equiv H_n ⊕ H_u
 \end{aligned}
+$$
 
 ### 3.3 Free Squaring
 
 In the actual implementation of the protocol we only compute odd multiplicative
-shares, i.e. \\(\overline{H}, \overline{H^3}, \overline{H^5}, \ldots\\), so that
+shares, i.e. $\overline{H}, \overline{H^3}, \overline{H^5}, \ldots$, so that
 we only need to share these odd shares in step **3**. This is possible because
 we can compute even additive shares from odd additive shares. We observe that
-for even \\(k\\):
+for even $k$:
 
+$$
 \begin{align}
 H^k &= (H_n^{k/2} ⊕ H_u^{k/2})^2 \\\\
 &= (H_n^{k/2})^2 ⊕ H_n^{k/2} H_u^{k/2} ⊕ H_u^{k/2} H_n^{k/2} ⊕ (H_u^{k/2})^2 \\\\
 &= (H_n^{k/2})^2 ⊕ (H_u^{k/2})^2 \\\\
 &= H_n^k ⊕ H_u^k
 \end{align}
+$$
 
 So we only need to convert odd multiplicative shares into odd additive shares,
 which means that we only need 50% of bandwidth in the corresponding OTs.

--- a/src/protocol/2pc/mac.md
+++ b/src/protocol/2pc/mac.md
@@ -48,9 +48,9 @@ field` described in section 6.3 of the NIST publication.
 * ⊕ is `addition in a finite field` and it is defined as XOR.
 
 In other words, GHASH splits up the ciphertext into 16-byte blocks, each block
-is numbered $X_1, X_2, ...$ etc. There's also $ H $
+is numbered $X_1, X_2, ...$ etc. There's also $H$
 which is called the `GHASH key`, which just is the AES-encrypted zero-block. We
-need to raise $ H $ to as many powers as there are blocks, i.e. if
+need to raise $H$ to as many powers as there are blocks, i.e. if
 we have 5 blocks then we need 5 powers: $H, H^2, H^3, H^4, H^5$.
 Each block is multiplied by the corresponding power and all products are summed
 together.
@@ -76,20 +76,20 @@ and distributive: $a(b+c)=ab+ac$.
 ## 3. Computing MAC using secure two-party computation (2PC) <a name="section3"></a>
 
 The goal of the protocol is to compute the MAC in such a way that neither party
-would learn the other party's share of $ H $ i.e. the `GHASH key`
+would learn the other party's share of $H$ i.e. the `GHASH key`
 share. At the start of the protocol each party has:
 1. ciphertext blocks $X_1, X_2, ..., X_m$.
-2. his XOR share of $ H $: the `User` has $ H_u $
-   and the `Notary` has $ H_n $.
-3. his XOR share of the `GCTR output`: the `User` has $ GCTR_u $
-   and the `Notary` has $ GCTR_n $.
+2. his XOR share of $H$: the `User` has $H_u$
+   and the `Notary` has $H_n$.
+3. his XOR share of the `GCTR output`: the `User` has $GCTR_u$
+   and the `Notary` has $GCTR_n$.
 
 Note that **2.** and **3.** were obtained at an earlier stage of the TLSNotary protocol.
 
 ### 3.1 Example with a single ciphertext block
 
 To illustrate what we want to achieve, we consider the case of just having
-a single ciphertext block $ X_1 $. The `GHASH_output` will be:
+a single ciphertext block $X_1$. The `GHASH_output` will be:
 
 $X_1•H = X_1•(H_u ⊕ H_n) = X_1•H_u ⊕ X_1•H_n$
 

--- a/src/protocol/notarization/key_exchange.md
+++ b/src/protocol/notarization/key_exchange.md
@@ -7,34 +7,34 @@ In TLS, the first step towards obtaining TLS session keys is to compute a shared
 Using the notation from Wikipedia, below is the 3-party ECDH protocol between the `Server` the `Requester` and the `Notary`, enabling the `Requester` and the `Notary` to arrive at shares of `PMS`.
 
 
-1. `Server` sends its public key \\(\small{Q_b}\\) to `Requester`, and `Requester` forwards it to `Notary`
-2. `Requester` picks a random private key share \\( \small{d_c} \\) and computes a public key share \\( \small{Q_c = d_c * G} \\)
-3. `Notary` picks a random private key share \\( \small{d_n} \\) and computes a public key share \\( \small{Q_n = d_n * G} \\)
-4. `Notary` sends \\( \small{Q_n} \\) to `Requester` who computes \\( \small{Q_a = Q_c + Q_n} \\) and sends \\( \small{Q_a} \\) to `Server`
-5. `Requester` computes an EC point \\( \small{(x_p, y_p) = d_c * Q_b} \\)
-6. `Notary` computes an EC point \\( \small{(x_q, y_q) = d_n * Q_b} \\)
-7. Addition of points \\( \small{(x_p, y_p)} \\) and \\( \small{(x_q, y_q)} \\) results in the coordinate \\( \small{x_r} \\), which is `PMS`. (The coordinate \\( \small{y_r} \\) is not used in TLS)
+1. `Server` sends its public key $Q_b$ to `Requester`, and `Requester` forwards it to `Notary`
+2. `Requester` picks a random private key share $d_c$ and computes a public key share $Q_c = d_c * G$
+3. `Notary` picks a random private key share $d_n$ and computes a public key share $Q_n = d_n * G$
+4. `Notary` sends $ Q_n $ to `Requester` who computes $Q_a = Q_c + Q_n $ and sends $ Q_a $ to `Server`
+5. `Requester` computes an EC point $(x_p, y_p) = d_c * Q_b$
+6. `Notary` computes an EC point $(x_q, y_q) = d_n * Q_b$
+7. Addition of points $(x_p, y_p)$ and $(x_q, y_q)$ results in the coordinate $ x_r $, which is `PMS`. (The coordinate $ y_r $ is not used in TLS)
 
 
 Using the notation from [here](https://en.wikipedia.org/wiki/Elliptic_curve_point_multiplication#Point_addition), our goal is to compute
-\\[ x_r = (\frac{y_q-y_p}{x_q-x_p})^2 - x_p - x_q \\]
+$$ x_r = (\frac{y_q-y_p}{x_q-x_p})^2 - x_p - x_q $$
 in such a way that
-1. Neither party learns the other party's \\( \small{x} \\) value
-2. Neither party learns \\( \small{x_r} \\), only their respective shares of \\( \small{x_r} \\).
+1. Neither party learns the other party's $ x $ value
+2. Neither party learns $ x_r $, only their respective shares of $ x_r $.
 
 We will use two maliciously secure protocols described on p.25 in the paper [Eﬃcient Secure Two-Party Exponentiation](https://www.cs.umd.edu/~fenghao/paper/modexp.pdf):
 
 - `A2M` protocol, which converts additive shares into multiplicative shares, i.e. given shares `a` and `b` such that `a + b = c`, it converts them into shares `d` and `e` such that `d * e = c`    
 - `M2A` protocol, which converts multiplicative shares into additive shares
 
-We apply `A2M` to \\(y_q + (-y_p)\\) to get \\(A_q * A_p\\) and also we apply `A2M` to \\(x_q + (-x_p)\\) to get \\(B_q * B_p\\). Then the above can be rewritten as:
+We apply `A2M` to $y_q + (-y_p)$ to get $A_q * A_p$ and also we apply `A2M` to $x_q + (-x_p)$ to get $B_q * B_p$. Then the above can be rewritten as:
 
-\\[x_r = (\frac{A_q}{B_q})^2 * (\frac{A_p}{B_p})^2 - x_p - x_q \\]
+$$x_r = (\frac{A_q}{B_q})^2 * (\frac{A_p}{B_p})^2 - x_p - x_q $$
 
-Then the first party locally computes the first factor and gets \\(C_q\\), the second party locally computes the second factor and gets \\(C_p\\). Then we can again rewrite as:
+Then the first party locally computes the first factor and gets $C_q$, the second party locally computes the second factor and gets $C_p$. Then we can again rewrite as:
 
-\\[x_r = C_q * C_p - x_p - x_q \\]
+$$x_r = C_q * C_p - x_p - x_q $$
 
-Now we apply `M2A` to \\(C_q * C_p\\) to get \\(D_q + D_p\\), which leads us to two final terms each of which is the share of \\(x_r\\) of the respective party: 
+Now we apply `M2A` to $C_q * C_p$ to get $D_q + D_p$, which leads us to two final terms each of which is the share of $x_r$ of the respective party: 
 
-\\[x_r = (D_q - x_q) + (D_p - x_p)\\]
+$$x_r = (D_q - x_q) + (D_p - x_p)$$

--- a/src/protocol/notarization/key_exchange.md
+++ b/src/protocol/notarization/key_exchange.md
@@ -10,17 +10,17 @@ Using the notation from Wikipedia, below is the 3-party ECDH protocol between th
 1. `Server` sends its public key $Q_b$ to `Requester`, and `Requester` forwards it to `Notary`
 2. `Requester` picks a random private key share $d_c$ and computes a public key share $Q_c = d_c * G$
 3. `Notary` picks a random private key share $d_n$ and computes a public key share $Q_n = d_n * G$
-4. `Notary` sends $ Q_n $ to `Requester` who computes $Q_a = Q_c + Q_n $ and sends $ Q_a $ to `Server`
+4. `Notary` sends $Q_n$ to `Requester` who computes $Q_a = Q_c + Q_n $ and sends $Q_a$ to `Server`
 5. `Requester` computes an EC point $(x_p, y_p) = d_c * Q_b$
 6. `Notary` computes an EC point $(x_q, y_q) = d_n * Q_b$
-7. Addition of points $(x_p, y_p)$ and $(x_q, y_q)$ results in the coordinate $ x_r $, which is `PMS`. (The coordinate $ y_r $ is not used in TLS)
+7. Addition of points $(x_p, y_p)$ and $(x_q, y_q)$ results in the coordinate $x_r$, which is `PMS`. (The coordinate $y_r$ is not used in TLS)
 
 
 Using the notation from [here](https://en.wikipedia.org/wiki/Elliptic_curve_point_multiplication#Point_addition), our goal is to compute
 $$ x_r = (\frac{y_q-y_p}{x_q-x_p})^2 - x_p - x_q $$
 in such a way that
-1. Neither party learns the other party's $ x $ value
-2. Neither party learns $ x_r $, only their respective shares of $ x_r $.
+1. Neither party learns the other party's $x$ value
+2. Neither party learns $x_r$, only their respective shares of $x_r$.
 
 We will use two maliciously secure protocols described on p.25 in the paper [Eﬃcient Secure Two-Party Exponentiation](https://www.cs.umd.edu/~fenghao/paper/modexp.pdf):
 


### PR DESCRIPTION
This PR replaces MathJax with KateX preprocessing and updates our docs to use the syntax we want: `$` for inline and `$$` for blocks.

This should make our docs render the same in markdown files as our html docs. Except Github's renderer... because it sucks

I also set a global css override which sizes the math font to the same as the surrounding fonts. The default before was 1.21x which I think looks ugly.