### PR TITLE
Prefer `user` over `client` and `requester`

### DIFF
--- a/src/protocol/notarization/README.md
+++ b/src/protocol/notarization/README.md
@@ -1,20 +1,20 @@
 # Notarization Phase
 
-During the Notarization Phase the `Requester`, otherwise referred to as the `User`, and the `Notary` work together to generate an authenticated `Transcript` of a TLS session with a `Server`.
+During the Notarization Phase the `User` (otherwise referred to as the `Requester` or `Prover`) and the `Notary` work together to generate an authenticated `Transcript` of a TLS session with a `Server`.
 
 Listed below are some key points regarding this process:
 
- - The identity of the `Server` is not revealed to the `Notary`, but the `Requester` is capable of proving the `Server` identity to a `Verifier` later.
+ - The identity of the `Server` is not revealed to the `Notary`, but the `User` is capable of proving the `Server` identity to a `Verifier` later.
  - The `Notary` only ever sees the *encrypted* application data of the TLS session.
- - The protocol guarantees that the `Requester` is not solely capable of constructing requests, nor can they forge responses from the `Server`.
+ - The protocol guarantees that the `User` is not solely capable of constructing requests, nor can they forge responses from the `Server`.
 
-## Requester
+## User
 
-The `Requester` is the party which runs the TLS connection with the `Server`. The `Requester` constructs application payloads, eg. HTTP requests, and coordinates with the `Notary` to encrypt them with the TLS session keys prior to sending them. Subsequently, the `Requester` works with the `Notary` to decrypt responses from the `Server`. The plaintext of the application data is only ever revealed to the `Requester`.
+The `User` is the party which runs the TLS connection with the `Server`. The `User` constructs application payloads, eg. HTTP requests, and coordinates with the `Notary` to encrypt them with the TLS session keys prior to sending them. Subsequently, the `User` works with the `Notary` to decrypt responses from the `Server`. The plaintext of the application data is only ever revealed to the `User`.
 
 ## Notary
 
-The `Notary` is the party of which the authenticity of the `Transcript` relies on. During the session the `Notary` withholds its' shares of the TLS keys and participates in a series of secure 2-party computation protocols with the `Requester` to operate the TLS connection.
+The `Notary` is the party of which the authenticity of the `Transcript` relies on. During the session the `Notary` withholds its' shares of the TLS keys and participates in a series of secure 2-party computation protocols with the `User` to operate the TLS connection.
 
 ## Server
 

--- a/src/protocol/notarization/key_exchange.md
+++ b/src/protocol/notarization/key_exchange.md
@@ -1,6 +1,6 @@
 # Key Exchange
 
-In TLS, the first step towards obtaining TLS session keys is to compute a shared secret between the client and the server by running the [ECDH protocol](https://en.wikipedia.org/wiki/Elliptic-curve_Diffie–Hellman). The resulting shared secret in TLS terms is called the pre-master secret `PMS`.
+In TLS, the first step towards obtaining TLS session keys is to compute a shared secret between the user and the server by running the [ECDH protocol](https://en.wikipedia.org/wiki/Elliptic-curve_Diffie–Hellman). The resulting shared secret in TLS terms is called the pre-master secret `PMS`.
 
 <img src="https://raw.githubusercontent.com/tlsnotary/docs-assets/main/diagrams/key_exchange.png" width="800">
 
@@ -22,7 +22,7 @@ in such a way that
 1. Neither party learns the other party's $x$ value
 2. Neither party learns $x_r$, only their respective shares of $x_r$.
 
-We will use two maliciously secure protocols described on p.25 in the paper [Eﬃcient Secure Two-Party Exponentiation](https://www.cs.umd.edu/~fenghao/paper/modexp.pdf):
+We will use two maliciously secure protocols described on p.25 in the paper [Efficient Secure Two-Party Exponentiation](https://www.cs.umd.edu/~fenghao/paper/modexp.pdf):
 
 - `A2M` protocol, which converts additive shares into multiplicative shares, i.e. given shares `a` and `b` such that `a + b = c`, it converts them into shares `d` and `e` such that `d * e = c`    
 - `M2A` protocol, which converts multiplicative shares into additive shares


### PR DESCRIPTION
I did not change [key_exchange.md](https://github.com/tlsnotary/docs-mdbook/blob/1a8d083dff495191907d6bb2a550c2e5567f9fb3/src/protocol/notarization/key_exchange.md#L4) because uses the notation from Wikipedia 