### PR TITLE
Tls handshake reworded

### DIFF
--- a/src/mpc/deap.md
+++ b/src/mpc/deap.md
@@ -2,10 +2,10 @@
 
 TLSNotary uses the `DEAP` protocol described below to ensure malicious security during the Encryption and Decryption steps.
 
-When using DEAP in TLSNotary, the `User` plays the role of Alice and has full privacy and the `Notary` plays the role of Bob and reveals all of his private inputs after the TLS session with the server is over. (The Notary's private inputs are his TLS session key shares).
+When using `DEAP` in TLSNotary, the `User` plays the role of Alice and has full privacy and the `Notary` plays the role of Bob and reveals all of his private inputs after the TLS session with the server is over. (The `Notary`'s private inputs are his TLS session key shares).
 
 The parties run the `Setup` and `Execution` steps of `DEAP` but they defer the `Equality Check`.
-Since during the `Equality Check` all of the Notary's secrets are revealed to User, it must be deferred until after the TLS session with the server is over, otherwise the User would learn the full TLS session keys and be able to forge the TLS transcript.
+Since during the `Equality Check` all of the `Notary`'s secrets are revealed to the `User`, it must be deferred until after the TLS session with the server is over, otherwise the `User` would learn the full TLS session keys and be able to forge the TLS transcript.
 
 ## Introduction
 

--- a/src/protocol/notarization/encryption.md
+++ b/src/protocol/notarization/encryption.md
@@ -1,10 +1,10 @@
 # Encryption, Decryption, and MAC Computation
 
-This section explains how the `User` and `Notary` use MPC to encrypt data for the server, decrypt data received from the server, and compute the MAC for the ciphertext in MPC.
+This section explains how the `User` and `Notary` use MPC to encrypt data for the server, decrypt data received from the server, and compute the MAC for the ciphertext using MPC.
 
 ## Encryption
 
-To encrypt the plaintext, both parties input their key shares as private inputs to the [MPC](/mpc/deap.md) protocol, along with some other public data. Additionally, the `User` inputs her plaintext as a private input.
+To encrypt the plaintext, both parties input their TLS key shares as private inputs to the [MPC](/mpc/deap.md) protocol, along with some other public data. Additionally, the `User` inputs her plaintext as a private input.
 
 Both parties see the resulting ciphertext and execute the [2PC MAC](../../mpc/mac.md) protocol to compute the MAC for the ciphertext.
 

--- a/src/protocol/notarization/handshake.md
+++ b/src/protocol/notarization/handshake.md
@@ -1,6 +1,6 @@
 # TLS Handshake
 
-A TLS handshake is the first step in establishing a TLS connection with a server. In TLSNotary the `User` is the one who starts the TLS handshake and physically communicates with the server but all cryptographic TLS operations are performed together with the `Notary` using MPC.
+A TLS handshake is the first step in establishing a TLS connection between a `User` and a `Server`. In TLSNotary the `User` is the one who starts the TLS handshake and physically communicates with the `Server`, but all cryptographic TLS operations are performed together with the `Notary` using MPC.
 
 The `User` and `Notary` use a series of MPC protocols to compute the TLS session key in such a way that each of them only has their share of the key and never learns the full key. The parties then proceed to complete the TLS handshake using their shares of the key.
 

--- a/src/protocol/notarization/handshake.md
+++ b/src/protocol/notarization/handshake.md
@@ -2,7 +2,7 @@
 
 A TLS handshake is the first step in establishing a TLS connection between a `User` and a `Server`. In TLSNotary the `User` is the one who starts the TLS handshake and physically communicates with the `Server`, but all cryptographic TLS operations are performed together with the `Notary` using MPC.
 
-The `User` and `Notary` use a series of MPC protocols to compute the TLS session key in such a way that each of them only has their share of the key and never learns the full key. The parties then proceed to complete the TLS handshake using their shares of the key.
+The `User` and `Notary` use a series of MPC protocols to compute the TLS session key in such a way that both only have their share of the key and never learn the full key. Both parties then proceed to complete the TLS handshake using their shares of the key.
 
 With the shares of the session key computed and the TLS handshake completed, the parties now proceed to the next MPC protocol where they use their session key shares to jointly generate encrypted requests and decrypt server responses while keeping the plaintext of both the requests and responses private from the `Notary`.
 

--- a/src/protocol/notarization/handshake.md
+++ b/src/protocol/notarization/handshake.md
@@ -1,13 +1,12 @@
 # TLS Handshake
 
-During the TLS handshake, the TLS Client and the TLS Server compute the session keys needed for the encryption and decryption of data.
+A TLS handshake is the first step in establishing a TLS connection with a server. In TLSNotary the `User` is the one who starts the TLS handshake and physically communicates with the server but all cryptographic TLS operations are performed together with the `Notary` using MPC.
 
-In TLSNotary protocol the `User` and `Notary` jointly play the role of the TLS Client. The `User` is the one who physically communicates with the server but all cryptographic TLS operations are performed using MPC.
+The `User` and `Notary` use a series of MPC protocols to compute the TLS session key in such a way that each of them only has their share of the key and never learns the full key. The parties then proceed to complete the TLS handshake using their shares of the key.
 
-The parties use MPC to compute the session keys in such a way that each party only has their share of the keys and never learns the full keys. The parties proceed to complete the TLS handshake using their shares of the keys.
+With the shares of the session key computed and the TLS handshake completed, the parties now proceed to the next MPC protocol where they use their session key shares to jointly generate encrypted requests and decrypt server responses while keeping the plaintext of both the requests and responses private from the `Notary`.
 
-To a third party observing the `User`'s connection to the server, the connection appears like a regular TLS connection. The `User` maintains all the security guarantees of a standard TLS connection against a third-party bad actor.
 
-However, the `User`'s TLS connection does not maintain the normal TLS security against the `Notary`. Instead, the `User` relies on the security which the underlying MPC protocols provide.
-
-With the shares of the session keys computed, the parties now proceed to the next MPC protocol where they use their session key shares to jointly encrypt requests to and decrypt responses from the server while keeping the plaintext of the request/response private from the `Notary`.
+> Note: to a third party observer, the `User`'s connection to the server appears like a regular TLS connection and the security guaranteed by TLS remains intact for the `User`.
+>
+> The only exception is that since the `Notary` is a party to the MPC TLS, the security for the `User` against a malicious `Notary` is guaranteed by the underlying MPC protocols and not by the TLS.


### PR DESCRIPTION
This PR rewords the TLS handshake for 2 reasons:

- It seemed that it is conceptually cleaner to speak of the TLS session "key" in singular vs "keys". 

- There is no advantage in emphasizing that "User+Notary==TLS Client". It is conceptually simpler if the User is the TLS Client and the Notary is the one who helps with cryptographic operations.