### PR TITLE
update wording in DEAP

### DIFF
--- a/src/mpc/deap.md
+++ b/src/mpc/deap.md
@@ -5,7 +5,7 @@ TLSNotary uses the `DEAP` protocol described below to ensure malicious security 
 When using DEAP in TLSNotary, the `User` plays the role of Alice and has full privacy and the `Notary` plays the role of Bob and reveals all of his private inputs after the TLS session with the server is over. The Notary's private input is his TLS session key share.
 
 The parties run the `Setup` and `Execution` steps of `DEAP` but they defer the `Equality Check`.
-Since during the `Equality Check` all of the Notary's secrets are revealed to User, it must be deferred until after the TLS session with the server is over, otherwise the User would learn the full TLS session keys and be able to forge the TLS transcript.
+Since during the `Equality Check` all of the `Notary`'s secrets are revealed to User, it must be deferred until after the TLS session with the server is over, otherwise the User would learn the full TLS session keys and be able to forge the TLS transcript.
 
 ## Introduction
 


### PR DESCRIPTION
This PR updates some of the wording in the DEAP introduction, as DEAP is used in more than just encryption and decryption. It is also more accurate that the Notary only has 1 private input, his share of the PMS.