### PR TITLE
reword mpc_tls

### DIFF
--- a/src/protocol/mpc-tls/README.md
+++ b/src/protocol/mpc-tls/README.md
@@ -1,12 +1,14 @@
 # MPC-TLS
 
-During the MPC-TLS phase the `Prover` and the `Verifier` work together to generate an authenticated `Transcript`[^transcript] of a TLS session with a `Server`.
+During the MPC-TLS phase the `Prover` and the `Verifier` run an MPC protocol enabling the `Prover` to connect to and exchange data with a TLS-enabled `Server`. 
 
-Listed below are some key points regarding this process:
 
-- The `Verifier` only ever sees the *encrypted* application data of the TLS session.
-- The protocol guarantees that the `Prover` is not solely capable of constructing requests, nor can they forge responses from the `Server`.
-- When the `Verifier` is a `Notary` (see section on [Notarization](../notarization.md)), the identity of the `Server` is hidden and can be proven to another application-specific verifier later.
+Listed below are some key points regarding this protocol:
+
+
+- The `Verifier` only learns the *encrypted* application data of the TLS session.
+- The `Prover` is not solely capable of constructing requests, nor can they forge responses from the `Server`.
+- The protocol enables the `Prover` to prove the authenticity of the exchanged data to the `Verifier`. 
 
 
 <!-- The MPC-TLS protocol consists of the following steps:
@@ -16,6 +18,3 @@ A TLS handshake is the first step in establishing a TLS connection between the `
 2. **Encryption, Decryption, and MAC Computation**  
 Next, the `Prover` and `Verifier` use MPC to encrypt, and decrypt, data sent to, and received from, the `Server`. They also compute a *Message Authentication Code (MAC)* 
 for the data that ensures untampered communication. -->
-
-
-[^transcript]: A transcript is the application level data that is send to and received from the `Server`

--- a/src/protocol/mpc-tls/README.md
+++ b/src/protocol/mpc-tls/README.md
@@ -1,6 +1,6 @@
 # MPC-TLS
 
-During the MPC-TLS phase the `Prover` and the `Verifier` run an MPC protocol enabling the `Prover` to connect to and exchange data with a TLS-enabled `Server`. 
+During the MPC-TLS phase the `Prover` and the `Verifier` run an MPC protocol enabling the `Prover` to connect to, and exchange data with, a TLS-enabled `Server`. 
 
 
 Listed below are some key points regarding this protocol:


### PR DESCRIPTION
This PR rewords the MPC-TLS section:

- disambiguate that it is the Prover who connects to the server
- remove the mention of a Notary to not distract from the more important Prover<->Verifier paradigm
- change "verifier sees" to "verifier learns", otherwise it sounds like the verifier is MITMing. 
- remove mention of Transcript since it is better to introduce it in the deeper sections of the docs
- added one more key point
