### PR TITLE
DEAP clarify that Enc means encode

### DIFF
--- a/src/mpc/deap.md
+++ b/src/mpc/deap.md
@@ -37,7 +37,7 @@ In the last phase of our protocol Bob must open all oblivious transfers he sent 
 
 * $x$ and $y$ are Alice and Bob's inputs, respectively.
 * $[X]_A$ denotes an encoding of $x$ chosen by Alice.
-* $[x]$ and $[y]$ are Alice and Bob's encoded _active_ inputs, respectively, ie $\mathsf{Enc}(x, [X]) = [x]$.
+* $[x]$ and $[y]$ are Alice and Bob's encoded _active_ inputs, respectively, ie $\mathsf{Encode}(x, [X]) = [x]$.
 * $\mathsf{com}_x$ denotes a binding commitment to $x$
 * $G$ denotes a garbled circuit for computing $f(x, y) = v$, where:
   *  $\mathsf{Gb}([X], [Y]) = G$


### PR DESCRIPTION
This PR clarifies that Enc in DEAP means encode to avoid confusion with Enc in https://docs.tlsnotary.org/mpc/encryption.html where it means encrypt.