### PR TITLE
Make proof contents and verification functionality clearer

### DIFF
--- a/src/quick_start/rust.md
+++ b/src/quick_start/rust.md
@@ -62,7 +62,7 @@ RUST_LOG=DEBUG,uid_mux=INFO,yamux=INFO cargo run --release --example simple_prov
 
 ### 2. Verify the Proof
 
-When you open `simple_proof.json` in an editor, you will see a JSON file with lots of non-human-readable byte arrays. You can decode this file by running:
+When you open `simple_proof.json` in an editor, you will see a JSON file with lots of non-human-readable byte arrays. (Note: The plaintext is included, in byte array form. ) You can verify this file and create a human-friendly output by running:
 
 ```shell
 cargo run --release --example simple_verifier


### PR DESCRIPTION
The original text said: "When you open `simple_proof.json` in an editor, you will see a JSON file with lots of non-human-readable byte arrays. You can decode this file by running:"

This confused me when I was trying to learn how to use TLSN, because it sounds like the proof does not contain the plain text, but that it rather has some kind of byte-oriented data  "decoded", which sounded to me like it did not contain any direct equivalent to the plaintext—I thought that it must be in encrypted form in the proof. But but the proof does include the plaintext, it's just that it's in byte array form, which is being verified and formatted by the verifier.